### PR TITLE
fix: display warning when issue level is `warn`

### DIFF
--- a/coffeelint-server/src/server.ts
+++ b/coffeelint-server/src/server.ts
@@ -58,7 +58,7 @@ function validateTextDocument(textDocument: ITextDocument): void {
   for(var issue of issues) {
     var severity;
     
-    if(issue.level === "warning") {
+    if(issue.level === "warn") {
       severity = DiagnosticSeverity.Warning;
     } else {
       severity = DiagnosticSeverity.Error;


### PR DESCRIPTION
vscode showed errors for lines that were actually warnings. This is because the value that is supplied to coffeelint severity level for warnings is 'warn'. Not 'warning'.